### PR TITLE
A `catch` should mark all previous promises in the chain as handled.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "es6"
   ],
   "devDependencies": {
+    "core-assert": "^0.1.1",
     "coveralls": "^2.11.4",
     "mocha": "*",
     "nyc": "^3.2.2",


### PR DESCRIPTION
UPDATE: See #11 - It mimics Node behavior, and won't leak memory.

Fixes #10

I just did what made sense to me here. As far as I know, there is no detailed
spec on exactly how to handle this. 

Perhaps add bluebird as a dev dependency and run our the relevant tests against that?
(insuring we behave the same as them).
