### PR TITLE
Detect node without browserify polyfilling `process`

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var SETTLED = 'settled';
 var FULFILLED = 'fulfilled';
 var REJECTED = 'rejected';
 var NOOP = function () {};
-var isNode = typeof process !== 'undefined' && typeof process.emit === 'function';
+var isNode = global.process !== 'undefined' && typeof global.process.emit === 'function';
 
 var asyncSetTimer = typeof setImmediate === 'undefined' ? setTimeout : setImmediate;
 var asyncQueue = [];
@@ -156,12 +156,12 @@ function publishRejection(promise) {
 	promise._state = REJECTED;
 	publish(promise);
 	if (!promise._handled && isNode) {
-		process.emit('unhandledRejection', promise._data, promise);
+		global.process.emit('unhandledRejection', promise._data, promise);
 	}
 }
 
 function notifyRejectionHandled(promise) {
-	process.emit('rejectionHandled', promise);
+	global.process.emit('rejectionHandled', promise);
 }
 
 /**


### PR DESCRIPTION
`typeof process === 'undefined'` caused browserify to polyfill `process` and `isNode` was never false. It added unneeded 4kb to the browserified version of pinkie. Replacing `process` to `global.process` fixes this issue.

Note, browserify will polyfill global to `window`, so it's never `undefined`.
