### PR TITLE
Extensible statics

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ Promise.all = function (promises) {
 		throw new TypeError('You must pass an array to Promise.all().');
 	}
 
-	return new Promise(function (resolve, reject) {
+	return new this(function (resolve, reject) {
 		var results = [];
 		var remaining = 0;
 
@@ -260,7 +260,7 @@ Promise.race = function (promises) {
 		throw new TypeError('You must pass an array to Promise.race().');
 	}
 
-	return new Promise(function (resolve, reject) {
+	return new this(function (resolve, reject) {
 		for (var i = 0, promise; i < promises.length; i++) {
 			promise = promises[i];
 
@@ -278,13 +278,13 @@ Promise.resolve = function (value) {
 		return value;
 	}
 
-	return new Promise(function (resolve) {
+	return new this(function (resolve) {
 		resolve(value);
 	});
 };
 
 Promise.reject = function (reason) {
-	return new Promise(function (resolve, reject) {
+	return new this(function (resolve, reject) {
 		reject(reason);
 	});
 };


### PR DESCRIPTION
Very small change to allow statics to be copied. The motivation is to extend pinkie with [`Promise.try`](https://github.com/tc39/proposal-promise-try) and [`Promise.prototype.finally`](https://github.com/tc39/proposal-promise-finally).

Mutating the pinkie `Promise` directly is not an option for us. That technique is the exact cause of some nasty bugs. It also violates the open and closed principal.

In the end, we'd like to be able to do the following:

```
import Pinkie from "pinkie";

class Promise extends Pinkie {
    static try(callback) {
        // ... try implementation
    }

    finally(callback) {
        // ... finally implementation
    }
}

// Requires statics to use dynamic `this`
Object.assign(Promise, Pinkie);

export default Object.freeze(Promise);
```